### PR TITLE
Add an extra sanity check to recipe index manipulation to prevent cra…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,34 +1,36 @@
-//version: 1644194279
+//version: 1652851397
 /*
 DO NOT CHANGE THIS FILE!
 
 Also, you may replace this file at any time if there is an update available.
 Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/build.gradle for updates.
- */
+*/
 
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.internal.logging.text.StyledTextOutput.Style
+import org.gradle.internal.logging.text.StyledTextOutputFactory
 
 import java.util.concurrent.TimeUnit
 
 buildscript {
     repositories {
         maven {
-            name = "forge"
-            url = "https://maven.minecraftforge.net"
+            name 'forge'
+            url 'https://maven.minecraftforge.net'
         }
         maven {
-            name = "sonatype"
-            url = "https://oss.sonatype.org/content/repositories/snapshots/"
+            name 'sonatype'
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
         }
         maven {
-            name = "Scala CI dependencies"
-            url = "https://repo1.maven.org/maven2/"
+            name 'Scala CI dependencies'
+            url 'https://repo1.maven.org/maven2/'
         }
         maven {
-            name = "jitpack"
-            url = "https://jitpack.io"
+            name 'jitpack'
+            url 'https://jitpack.io'
         }
     }
     dependencies {
@@ -37,20 +39,26 @@ buildscript {
 }
 
 plugins {
+    id 'java-library'
     id 'idea'
     id 'eclipse'
     id 'scala'
-    id('org.jetbrains.kotlin.jvm') version ('1.6.10') apply false
-    id('org.ajoberstar.grgit') version('4.1.1')
-    id('com.github.johnrengelman.shadow') version('4.0.4')
-    id('com.palantir.git-version') version('0.13.0') apply false
-    id('de.undercouch.download') version('5.0.1')
-    id('maven-publish')
+    id 'maven-publish'
+    id 'org.jetbrains.kotlin.jvm'        version '1.5.30'       apply false
+    id 'org.jetbrains.kotlin.kapt'       version '1.5.30'       apply false
+    id 'com.google.devtools.ksp'         version '1.5.30-1.0.0' apply false
+    id 'org.ajoberstar.grgit'            version '4.1.1'
+    id 'com.github.johnrengelman.shadow' version '4.0.4'
+    id 'com.palantir.git-version'        version '0.13.0'       apply false
+    id 'de.undercouch.download'          version '5.0.1'
+    id 'com.github.gmazzo.buildconfig'   version '3.0.3'        apply false
 }
 
 if (project.file('.git/HEAD').isFile()) {
     apply plugin: 'com.palantir.git-version'
 }
+
+def out = services.get(StyledTextOutputFactory).create('an-output')
 
 apply plugin: 'forge'
 
@@ -96,6 +104,7 @@ checkPropertyExists("usesShadowedDependencies")
 checkPropertyExists("developmentEnvironmentUserName")
 
 boolean noPublishedSources = project.findProperty("noPublishedSources") ? project.noPublishedSources.toBoolean() : false
+boolean usesMixinDebug = project.findProperty('usesMixinDebug') ?: project.usesMixins.toBoolean()
 
 String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
@@ -167,8 +176,8 @@ configurations.all {
 try {
     'git config core.fileMode false'.execute()
 }
-catch (Exception e) {
-    logger.error("\u001B[31mgit isn't installed at all\u001B[0m")
+catch (Exception ignored) {
+    out.style(Style.Failure).println("git isn't installed at all")
 }
 
 // Pulls version first from the VERSION env and then git tag
@@ -177,19 +186,22 @@ String versionOverride = System.getenv("VERSION") ?: null
 try {
     identifiedVersion = versionOverride == null ? gitVersion() : versionOverride
 }
-catch (Exception e) {
-    logger.error("\n\u001B[1;31mThis mod must be version controlled by Git AND the repository must provide at least one tag,\n" +
-                 "or the VERSION override must be set! \u001B[32m(Don't download from GitHub using the ZIP option, instead\n" +
-                 "clone the repository, see\u001B[33m https://gtnh.miraheze.org/wiki/Development \u001B[32mfor details.)\u001B[0m\n");
+catch (Exception ignored) {
+    out.style(Style.Failure).text(
+        'This mod must be version controlled by Git AND the repository must provide at least one tag,\n' +
+        'or the VERSION override must be set! ').style(Style.SuccessHeader).text('(Do NOT download from GitHub using the ZIP option, instead\n' +
+        'clone the repository, see ').style(Style.Info).text('https://gtnh.miraheze.org/wiki/Development').style(Style.SuccessHeader).println(' for details.)'
+    )
     versionOverride = 'NO-GIT-TAG-SET'
     identifiedVersion = versionOverride
 }
 version = minecraftVersion + '-' + identifiedVersion
-String modVersion = identifiedVersion
+ext {
+    modVersion = identifiedVersion
+}
 
-if( identifiedVersion.equals(versionOverride) ) {
-    logger.error('\u001B[31m\u001B[7mWe hope you know what you\'re doing using\u001B[0m\u001B[1;34m ' + modVersion + '\u001B[0m\n');
-    logger.error('\7\u001B[31mGoing to blindly try to use\u001B[1;34m ' + modVersion + '\u001B[0m\u001B[31m, this probably won\'t work the way you expect!!\u001B[0m\n');
+if(identifiedVersion == versionOverride) {
+    out.style(Style.Failure).text('Override version to ').style(Style.Identifier).text(modVersion).style(Style.Failure).println('!\7')
 }
 
 group = modGroup
@@ -200,22 +212,25 @@ else {
     archivesBaseName = modId
 }
 
-
 def arguments = []
 def jvmArguments = []
 
-if(usesMixins.toBoolean()) {
+if (usesMixins.toBoolean()) {
     arguments += [
-            "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
+        "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
     ]
-    jvmArguments += [
-            "-Dmixin.debug.countInjections=true", "-Dmixin.debug.verbose=true", "-Dmixin.debug.export=true"
-    ]
+    if (usesMixinDebug.toBoolean()) {
+        jvmArguments += [
+            "-Dmixin.debug.countInjections=true",
+            "-Dmixin.debug.verbose=true",
+            "-Dmixin.debug.export=true"
+        ]
+    }
 }
 
 minecraft {
-    version = minecraftVersion + "-" + forgeVersion + "-" + minecraftVersion
-    runDir = "run"
+    version = minecraftVersion + '-' + forgeVersion + '-' + minecraftVersion
+    runDir = 'run'
 
     if (replaceGradleTokenInFile) {
         replaceIn replaceGradleTokenInFile
@@ -248,8 +263,8 @@ minecraft {
     }
 }
 
-if(file("addon.gradle").exists()) {
-    apply from: "addon.gradle"
+if(file('addon.gradle').exists()) {
+    apply from: 'addon.gradle'
 }
 
 apply from: 'repositories.gradle'
@@ -262,58 +277,63 @@ configurations {
 
 repositories {
     maven {
-        name = "Overmind forge repo mirror"
-        url = "https://gregtech.overminddl1.com/"
+        name 'Overmind forge repo mirror'
+        url 'https://gregtech.overminddl1.com/'
     }
     if(usesMixins.toBoolean()) {
         maven {
-            name = "sponge"
-            url = "https://repo.spongepowered.org/repository/maven-public"
+            name 'sponge'
+            url 'https://repo.spongepowered.org/repository/maven-public'
         }
         maven {
-            url = "https://jitpack.io"
+            url 'https://jitpack.io'
         }
     }
 }
 
 dependencies {
     if(usesMixins.toBoolean()) {
-        annotationProcessor("org.ow2.asm:asm-debug-all:5.0.3")
-        annotationProcessor("com.google.guava:guava:24.1.1-jre")
-        annotationProcessor("com.google.code.gson:gson:2.8.6")
-        annotationProcessor("org.spongepowered:mixin:0.8-SNAPSHOT")
+        annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
+        annotationProcessor('com.google.guava:guava:24.1.1-jre')
+        annotationProcessor('com.google.code.gson:gson:2.8.6')
+        annotationProcessor('org.spongepowered:mixin:0.8-SNAPSHOT')
         // using 0.8 to workaround a issue in 0.7 which fails mixin application
-        compile("com.github.GTNewHorizons:SpongePoweredMixin:0.7.12-GTNH") {
+        compile('com.github.GTNewHorizons:SpongePoweredMixin:0.7.12-GTNH') {
             // Mixin includes a lot of dependencies that are too up-to-date
-            exclude module: "launchwrapper"
-            exclude module: "guava"
-            exclude module: "gson"
-            exclude module: "commons-io"
-            exclude module: "log4j-core"
+            exclude module: 'launchwrapper'
+            exclude module: 'guava'
+            exclude module: 'gson'
+            exclude module: 'commons-io'
+            exclude module: 'log4j-core'
         }
-        compile("com.github.GTNewHorizons:SpongeMixins:1.5.0")
+        compile('com.github.GTNewHorizons:SpongeMixins:1.5.0')
     }
 }
 
 apply from: 'dependencies.gradle'
 
-def mixingConfigRefMap = "mixins." + modId + ".refmap.json"
+def mixingConfigRefMap = 'mixins.' + modId + '.refmap.json'
 def refMap = "${tasks.compileJava.temporaryDir}" + File.separator + mixingConfigRefMap
 def mixinSrg = "${tasks.reobf.temporaryDir}" + File.separator + "mixins.srg"
 
 task generateAssets {
-    if(usesMixins.toBoolean()) {
-        getFile("/src/main/resources/mixins." + modId + ".json").text = """{
+    if (usesMixins.toBoolean()) {
+        def mixinConfigFile = getFile("/src/main/resources/mixins." + modId + ".json");
+        if (!mixinConfigFile.exists()) {
+            mixinConfigFile.text = """{
   "required": true,
   "minVersion": "0.7.11",
   "package": "${modGroup}.${mixinsPackage}",
   "plugin": "${modGroup}.${mixinPlugin}",
   "refmap": "${mixingConfigRefMap}",
   "target": "@env(DEFAULT)",
-  "compatibilityLevel": "JAVA_8"
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "client": [],
+  "server": []
 }
-
 """
+        }
     }
 }
 
@@ -401,17 +421,16 @@ tasks.withType(JavaExec).configureEach {
     )
 }
 
-processResources
-{
+processResources {
     // this will ensure that this task is redone when the versions change.
     inputs.property "version", project.version
     inputs.property "mcversion", project.minecraft.version
-    
+
     // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
 
-        // replace version and mcversion
+        // replace modVersion and minecraftVersion
         expand "minecraftVersion": project.minecraft.version,
             "modVersion": modVersion,
             "modId": modId,
@@ -422,7 +441,7 @@ processResources
         from refMap
     }
 
-    // copy everything else, thats not the mcmod.info
+    // copy everything else that's not the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'
     }
@@ -430,7 +449,7 @@ processResources
 
 def getManifestAttributes() {
     def manifestAttributes = [:]
-    if(containsMixinsAndOrCoreModOnly.toBoolean() == false && (usesMixins.toBoolean() || coreModClass)) {
+    if(!containsMixinsAndOrCoreModOnly.toBoolean() && (usesMixins.toBoolean() || coreModClass)) {
         manifestAttributes += ["FMLCorePluginContainsFMLMod": true]
     }
 
@@ -446,14 +465,14 @@ def getManifestAttributes() {
         manifestAttributes += [
                 "TweakClass" : "org.spongepowered.asm.launch.MixinTweaker",
                 "MixinConfigs" : "mixins." + modId + ".json",
-                "ForceLoadAsMod" : containsMixinsAndOrCoreModOnly.toBoolean() == false
+                "ForceLoadAsMod" : !containsMixinsAndOrCoreModOnly.toBoolean()
         ]
     }
     return manifestAttributes
 }
 
 task sourcesJar(type: Jar) {
-    from (sourceSets.main.allJava)
+    from (sourceSets.main.allSource)
     from (file("$projectDir/LICENSE"))
     getArchiveClassifier().set('sources')
 }
@@ -508,7 +527,7 @@ task devJar(type: Jar) {
 }
 
 task apiJar(type: Jar) {
-    from (sourceSets.main.allJava) {
+    from (sourceSets.main.allSource) {
         include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
     }
 
@@ -533,14 +552,15 @@ artifacts {
     }
 }
 
-// The gradle metadata includes all of the additional deps that we disabled from POM generation (including forgeBin with no groupID), 
+// The gradle metadata includes all of the additional deps that we disabled from POM generation (including forgeBin with no groupID),
 // and isn't strictly needed with the POM so just disable it.
 tasks.withType(GenerateModuleMetadata) {
     enabled = false
 }
 
+// workaround variable hiding in pom processing
+def projectConfigs = project.configurations
 
-// publishing
 publishing {
     publications {
         maven(MavenPublication) {
@@ -549,7 +569,7 @@ publishing {
                 artifact source: shadowJar, classifier: ""
             }
             if(!noPublishedSources) {
-                artifact source: sourcesJar, classifier: "src"
+                artifact source: sourcesJar, classifier: "sources"
             }
             artifact source: usesShadowedDependencies.toBoolean() ? shadowDevJar : devJar, classifier: "dev"
             if (apiPackage) {
@@ -560,14 +580,21 @@ publishing {
             artifactId = System.getenv("ARTIFACT_ID") ?: project.name
             // Using the identified version, not project.version as it has the prepended 1.7.10
             version = System.getenv("RELEASE_VERSION") ?: identifiedVersion
-            
-            // Remove all non GTNH deps here.
-            // Original intention was to remove an invalid forgeBin being generated without a groupId (mandatory), but
-            // it also removes all of the MC deps
+
+            // remove extra garbage from minecraft and minecraftDeps configuration
             pom.withXml {
+                def badArtifacts = [:].withDefault {[] as Set<String>}
+                for (configuration in [projectConfigs.minecraft, projectConfigs.minecraftDeps]) {
+                    for (dependency in configuration.allDependencies) {
+                        badArtifacts[dependency.group == null ? "" : dependency.group] += dependency.name
+                    }
+                }
+                // example for specifying extra stuff to ignore
+                // badArtifacts["org.example.group"] += "artifactName"
+
                 Node pomNode = asNode()
                 pomNode.dependencies.'*'.findAll() {
-                    it.groupId.text() != 'com.github.GTNewHorizons'
+                    badArtifacts[it.groupId.text()].contains(it.artifactId.text())
                 }.each() {
                     it.parent().remove(it)
                 }
@@ -599,7 +626,7 @@ if (isNewBuildScriptVersionAvailable(projectDir.toString())) {
     if (autoUpdateBuildScript.toBoolean()) {
         performBuildScriptUpdate(projectDir.toString())
     } else {
-        println("Build script update available! Run 'gradle updateBuildScript'")
+        out.style(Style.SuccessHeader).println("Build script update available! Run 'gradle updateBuildScript'")
     }
 }
 
@@ -611,7 +638,7 @@ boolean performBuildScriptUpdate(String projectDir) {
     if (isNewBuildScriptVersionAvailable(projectDir)) {
         def buildscriptFile = getFile("build.gradle")
         availableBuildScriptUrl().withInputStream { i -> buildscriptFile.withOutputStream { it << i } }
-        print("Build script updated. Please REIMPORT the project or RESTART your IDE!")
+        out.style(Style.Success).print("Build script updated. Please REIMPORT the project or RESTART your IDE!")
         return true
     }
     return false
@@ -673,26 +700,26 @@ def deobf(String sourceURL) {
     }
 }
 
-// The method above is to be prefered. Use this method if the filename is not at the end of the URL.
+// The method above is to be preferred. Use this method if the filename is not at the end of the URL.
 def deobf(String sourceURL, String fileName) {
     String cacheDir = System.getProperty("user.home") + "/.gradle/caches/"
     String bon2Dir = cacheDir + "forge_gradle/deobf"
     String bon2File  = bon2Dir + "/BON2-2.5.0.jar"
     String obfFile = cacheDir + "modules-2/files-2.1/" + fileName + ".jar"
     String deobfFile = cacheDir + "modules-2/files-2.1/" + fileName + "-deobf.jar"
-    
+
     if(file(deobfFile).exists()) {
         return files(deobfFile)
     }
 
-    download {
+    download.run {
         src 'https://github.com/GTNewHorizons/BON2/releases/download/2.5.0/BON2-2.5.0.CUSTOM-all.jar'
         dest bon2File
         quiet true
         overwrite false
     }
 
-    download {
+    download.run {
         src sourceURL
         dest obfFile
         quiet true
@@ -711,7 +738,7 @@ def deobf(String sourceURL, String fileName) {
 // Helper methods
 
 def checkPropertyExists(String propertyName) {
-    if (project.hasProperty(propertyName) == false) {
+    if (!project.hasProperty(propertyName)) {
         throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"gradle.properties\". You can find all properties and their description here: https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/gradle.properties")
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,17 +1,17 @@
 dependencies {
-    compile("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-75-GTNH:dev")
+    compile("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-84-GTNH:dev")
     compile("com.github.GTNewHorizons:CodeChickenLib:1.1.5.3:dev")
     compile("com.github.GTNewHorizons:CodeChickenCore:1.1.3:dev")
-    compile("com.github.GTNewHorizons:NotEnoughItems:2.2.7-GTNH:dev")
+    compile("com.github.GTNewHorizons:NotEnoughItems:2.2.15-GTNH:dev")
     compile("com.github.GTNewHorizons:Baubles:1.0.1.14:dev")
-    compile("com.github.GTNewHorizons:WirelessCraftingTerminal:1.8.8.3:dev")
+    compile("com.github.GTNewHorizons:WirelessCraftingTerminal:1.8.8.5:dev")
 
     compileOnly("com.github.GTNewHorizons:Avaritiaddons:1.5.3-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:BuildCraftCompat:7.1.9:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:EnderIO:2.3.1.29:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.4.5:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.40.31:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GTplusplus:1.7.27:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:BuildCraftCompat:7.1.11:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:EnderIO:2.3.1.32:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.4.6:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.40.48:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GTplusplus:1.7.32:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:ThaumicEnergistics:1.3.16-GTNH:dev") { transitive = false }
     compileOnly("com.gregoriust.gregtech:gregtech_1.7.10:6.14.23:dev") { transitive = false }
     compileOnly("curse.maven:thaumcraft-nei-plugin-225095:2241913") { transitive = false }

--- a/src/main/java/com/github/vfyjxf/nee/client/NEEContainerDrawHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/client/NEEContainerDrawHandler.java
@@ -195,7 +195,7 @@ public class NEEContainerDrawHandler {
                     recipeIndex = gui.page * handler.recipiesPerPage() + i;
                 }
 
-                if (recipeIndex >= 0 && handler != null) {
+                if (recipeIndex >= 0 && handler != null && recipeIndex < handler.numRecipes()) {
                     IngredientTracker tracker = this.isCraftingTerm ? new IngredientTracker(gui.firstGui, handler, recipeIndex) : new IngredientTracker(gui, handler, recipeIndex);
                     trackerMap.put(overlayButton.id, tracker);
                 }


### PR DESCRIPTION
Fix <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10444>.
I'm not fully sure why the recipeIndex can end up wrong, but this way the handler for the missing recipe just won't be constructed (which is null-safe where the map is used later), rather than crashing with an out of bounds exception.