### PR TITLE
Fix "Combine Items" button overlap with "Use as substitution"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
-//version: 1666118075
+//version: 1670779107
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
- Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/build.gradle for updates.
+ Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/master/build.gradle for updates.
  */
 
 
@@ -31,7 +31,7 @@ buildscript {
             url 'https://maven.minecraftforge.net'
         }
         maven {
-            // GTNH ForgeGradle Fork
+            // GTNH ForgeGradle and ASM Fork
             name = "GTNH Maven"
             url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
@@ -45,7 +45,9 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.9'
+        //Overwrite the current ASM version to fix shading newer than java 8 applicatations.
+        classpath 'org.ow2.asm:asm-debug-all-custom:5.0.3'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.11'
     }
 }
 plugins {
@@ -330,6 +332,12 @@ repositories {
             name = "GTNH Maven"
             url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
+        if (usesMixinDebug.toBoolean()) {
+            maven {
+                name = "Fabric Maven"
+                url = "https://maven.fabricmc.net/"
+            }
+        }
     }
 }
 
@@ -338,10 +346,13 @@ dependencies {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
-        annotationProcessor('org.spongepowered:mixin:0.8.5-GTNH:processor')
+        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.3:processor')
+        if (usesMixinDebug.toBoolean()) {
+            runtimeOnly('org.jetbrains:intellij-fernflower:1.2.1.16')
+        }
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        compile('com.gtnewhorizon:gtnhmixins:2.0.1')
+        compile('com.gtnewhorizon:gtnhmixins:2.1.3')
     }
 }
 
@@ -694,7 +705,7 @@ if (modrinthProjectId.size() != 0 && System.getenv("MODRINTH_TOKEN") != null) {
         }
     }
     if (usesMixins.toBoolean()) {
-        addModrinthDep("required", "version", "gtnhmixins")
+        addModrinthDep("required", "project", "gtnhmixins")
     }
     tasks.modrinth.dependsOn(build)
     tasks.publish.dependsOn(tasks.modrinth)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-104-GTNH:dev")
+    compile("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-122-GTNH:dev")
     compile("com.github.GTNewHorizons:CodeChickenLib:1.1.5.5:dev")
     compile("com.github.GTNewHorizons:CodeChickenCore:1.1.6:dev")
     compile("com.github.GTNewHorizons:NotEnoughItems:2.3.2-GTNH:dev")

--- a/src/main/java/com/github/vfyjxf/nee/client/GuiEventHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/client/GuiEventHandler.java
@@ -42,6 +42,7 @@ public class GuiEventHandler implements INEIGuiHandler {
 
     private GuiImgButtonEnableCombination buttonCombination;
     private boolean hasDoubleBtn = true;
+    private boolean hasBeSubstituteBtn = true;
 
     @SubscribeEvent
     public void onGuiOpen(GuiOpenEvent event) {
@@ -97,17 +98,25 @@ public class GuiEventHandler implements INEIGuiHandler {
             } catch (NoSuchFieldException e) {
                 hasDoubleBtn = false;
             }
-            if (hasDoubleBtn) {
-                buttonCombination = new GuiImgButtonEnableCombination(
-                        gui.guiLeft + 84,
-                        gui.guiTop + gui.ySize - 153,
-                        ItemCombination.valueOf(NEEConfig.itemCombinationMode));
-            } else {
-                buttonCombination = new GuiImgButtonEnableCombination(
-                        gui.guiLeft + 74,
-                        gui.guiTop + gui.ySize - 153,
-                        ItemCombination.valueOf(NEEConfig.itemCombinationMode));
+            try {
+                GuiPatternTerm.class.getDeclaredField("beSubstitutionsEnabledBtn");
+            } catch (NoSuchFieldException e) {
+                hasBeSubstituteBtn = false;
             }
+
+            int x, y;
+            if (hasDoubleBtn && hasBeSubstituteBtn) {
+                x = gui.guiLeft + 84;
+                y = gui.guiTop + gui.ySize - 143;
+            } else if (hasDoubleBtn) {
+                x = gui.guiLeft + 84;
+                y = gui.guiTop + gui.ySize - 153;
+            } else {
+                x = gui.guiLeft + 74;
+                y = gui.guiTop + gui.ySize - 153;
+            }
+            buttonCombination =
+                    new GuiImgButtonEnableCombination(x, y, ItemCombination.valueOf(NEEConfig.itemCombinationMode));
             event.buttonList.add(buttonCombination);
         }
     }


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11959
I also noticed clicking "Search Box Mode" removes the combine items button, but haven't tracked down the cause.