### PR TITLE
fix crash when using nei to fill pattern in pattern terminal without ae2fc

### DIFF
--- a/src/main/java/com/github/vfyjxf/nee/nei/NEECraftingHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/nei/NEECraftingHandler.java
@@ -19,6 +19,7 @@ import com.github.vfyjxf.nee.processor.RecipeProcessor;
 import com.github.vfyjxf.nee.utils.ItemUtils;
 import com.github.vfyjxf.nee.utils.ModIDs;
 import com.glodblock.github.nei.FluidPatternTerminalRecipeTransferHandler;
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;
 import java.util.*;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -75,7 +76,7 @@ public class NEECraftingHandler implements IOverlayHandler {
     public void overlayRecipe(GuiContainer firstGui, IRecipeHandler recipe, int recipeIndex, boolean shift) {
         if (isPatternTerm(firstGui)) {
             NEENetworkHandler.getInstance().sendToServer(packRecipe(recipe, recipeIndex));
-            fluidCraftOverlayRecipe(firstGui, recipe, recipeIndex, shift);
+            if (Loader.isModLoaded(ModIDs.FC)) fluidCraftOverlayRecipe(firstGui, recipe, recipeIndex, shift);
         } else {
             knowledgeInscriberHandler(firstGui, recipe, recipeIndex);
             extremeAutoCrafterHandler(firstGui, recipe, recipeIndex);

--- a/src/main/java/com/github/vfyjxf/nee/network/packet/PacketNEIPatternRecipe.java
+++ b/src/main/java/com/github/vfyjxf/nee/network/packet/PacketNEIPatternRecipe.java
@@ -13,6 +13,7 @@ import appeng.helpers.IContainerCraftingPacket;
 import com.github.vfyjxf.nee.utils.ModIDs;
 import com.glodblock.github.client.gui.container.ContainerFluidPatternTerminal;
 import com.glodblock.github.client.gui.container.ContainerFluidPatternTerminalEx;
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
@@ -72,7 +73,7 @@ public class PacketNEIPatternRecipe implements IMessage {
                 ((ContainerPatternTermEx) container).getPatternTerminal().setInverted(false);
                 message.processRecipeHandler((ContainerPatternTermEx) container, message);
             }
-            addFluidCraftSupport(message, ctx);
+            if (Loader.isModLoaded(ModIDs.FC)) addFluidCraftSupport(message, ctx);
             return null;
         }
 


### PR DESCRIPTION
 fix crash when using nei to fill pattern in pattern terminal without ae2fc