### PR TITLE
Fix References to AE2FC Refactor

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,13 +6,13 @@ dependencies {
     compile("com.github.GTNewHorizons:Baubles:1.0.1.14:dev")
     compile("com.github.GTNewHorizons:WirelessCraftingTerminal:1.8.9.1:dev")
 
-    compileOnly("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.0.15-gtnh:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.0.58-gtnh:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Avaritiaddons:1.5.4-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:BuildCraftCompat:7.1.12:dev") { transitive = false }
     compileOnly('com.github.GTNewHorizons:EnderIO:2.3.1.47:dev') {transitive=false}
     compileOnly("com.github.GTNewHorizons:ForestryMC:4.4.14:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.41.37:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GTplusplus:1.7.90:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.41.239:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GTplusplus:1.7.201:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:ThaumicEnergistics:1.3.19-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Botania:1.9.11-GTNH:dev") { transitive = false }
     compileOnly("com.gregoriust.gregtech:gregtech_1.7.10:6.14.23:dev") { transitive = false }

--- a/src/main/java/com/github/vfyjxf/nee/processor/GregTech5RecipeProcessor.java
+++ b/src/main/java/com/github/vfyjxf/nee/processor/GregTech5RecipeProcessor.java
@@ -3,7 +3,7 @@ package com.github.vfyjxf.nee.processor;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.recipe.IRecipeHandler;
 import com.github.vfyjxf.nee.utils.GuiUtils;
-import com.glodblock.github.client.gui.GuiBaseFluidPatternTerminalEx;
+import com.glodblock.github.client.gui.GuiFluidPatternTerminalEx;
 import gregtech.api.enums.ItemList;
 import gregtech.api.util.GT_Recipe;
 import gregtech.nei.GT_NEI_DefaultHandler.FixedPositionedStack;
@@ -85,7 +85,7 @@ public class GregTech5RecipeProcessor implements IRecipeProcessor {
         if (gtDefaultClz.isInstance(recipe) || gtAssLineClz.isInstance(recipe)) {
             if (GuiUtils.isFluidCraftPatternTermEx(Minecraft.getMinecraft().currentScreen)) {
                 boolean priority =
-                        ((GuiBaseFluidPatternTerminalEx) Minecraft.getMinecraft().currentScreen).container.prioritize;
+                        ((GuiFluidPatternTerminalEx) Minecraft.getMinecraft().currentScreen).container.prioritize;
                 if (priority) {
                     for (PositionedStack ps : recipe.getIngredientStacks(recipeIndex)) {
                         if (ps != null && getFluidFromDisplayStack(ps.item) != null) {

--- a/src/main/java/com/github/vfyjxf/nee/utils/IngredientTracker.java
+++ b/src/main/java/com/github/vfyjxf/nee/utils/IngredientTracker.java
@@ -14,7 +14,7 @@ import codechicken.nei.recipe.IRecipeHandler;
 import com.github.vfyjxf.nee.config.NEEConfig;
 import com.github.vfyjxf.nee.network.NEENetworkHandler;
 import com.github.vfyjxf.nee.network.packet.PacketCraftingRequest;
-import com.glodblock.github.client.gui.GuiFCBaseMonitor;
+import com.glodblock.github.client.gui.base.FCGuiMonitor;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 import java.util.ArrayList;
 import java.util.List;
@@ -80,7 +80,7 @@ public class IngredientTracker {
     private ItemRepo getRepo() throws IllegalAccessException {
         if (isFluidCraftPatternTerm(termGui)) {
             return (ItemRepo)
-                    ReflectionHelper.findField(GuiFCBaseMonitor.class, "repo").get(termGui);
+                    ReflectionHelper.findField(FCGuiMonitor.class, "repo").get(termGui);
         } else {
             return (ItemRepo)
                     ReflectionHelper.findField(GuiMEMonitorable.class, "repo").get(termGui);


### PR DESCRIPTION
Fixed References to classes in AE2FC that have been either renamed or refactored, as well as a reflection exception due to the refactor.

Not sure if the GT5 and GT++ Dependencies are required, but they were not able to be resolved by Gradle (assume they have been pruned in Maven).

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12380