### PR TITLE
Allow bigger stack sizes to be dragged into pattern terminals

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,24 +1,24 @@
 dependencies {
-    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-312-GTNH:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.5.4-GTNH:dev")
+    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-352-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.5.27-GTNH:dev")
     implementation("com.github.GTNewHorizons:Baubles:1.0.4:dev")
-    implementation("com.github.GTNewHorizons:WirelessCraftingTerminal:1.11.0:dev")
+    implementation("com.github.GTNewHorizons:WirelessCraftingTerminal:1.11.2:dev")
 
-    compileOnly("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.2.13-gtnh:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Avaritiaddons:1.7.0-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.2.28-gtnh:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Avaritiaddons:1.7.1-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:BuildCraftCompat:7.1.17:dev") { transitive = false }
-    compileOnly('com.github.GTNewHorizons:EnderIO:2.6.4:dev') { transitive=false }
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.8.2:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.47:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:ThaumicEnergistics:1.6.2-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.2.13-gtnh:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Avaritiaddons:1.7.0-GTNH:dev") { transitive = false }
+    compileOnly('com.github.GTNewHorizons:EnderIO:2.7.4:dev') { transitive=false }
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.8.9:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.163:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ThaumicEnergistics:1.6.5-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.2.28-gtnh:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Avaritiaddons:1.7.1-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:BuildCraftCompat:7.1.17:dev") { transitive = false }
-    compileOnly('com.github.GTNewHorizons:EnderIO:2.6.4:dev') {transitive=false}
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.8.2:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GTplusplus:1.11.19:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:ThaumicEnergistics:1.6.2-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Botania:1.10.5-GTNH:dev") { transitive = false }
+    compileOnly('com.github.GTNewHorizons:EnderIO:2.7.4:dev') {transitive=false}
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.8.9:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GTplusplus:1.11.58:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ThaumicEnergistics:1.6.5-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Botania:1.10.12-GTNH:dev") { transitive = false }
     compileOnly("com.gregoriust.gregtech:gregtech_1.7.10:6.14.23:dev") { transitive = false }
     compileOnly("curse.maven:thaumcraft-nei-plugin-225095:2241913") { transitive = false }
     compileOnly("curse.maven:thermal-expansion-69163:2388759") { transitive = false }

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -60,6 +60,9 @@ gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -114,7 +117,7 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ customArchiveBaseName = NotEnoughEnergistics
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.22'
 }
 
 

--- a/src/main/java/com/github/vfyjxf/nee/client/GuiEventHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/client/GuiEventHandler.java
@@ -204,14 +204,13 @@ public class GuiEventHandler implements INEIGuiHandler {
                         if (button == 0) {
                             boolean areStackEqual = slotStack != null && slotStack.isItemEqual(copyStack)
                                     && ItemStack.areItemStackTagsEqual(slotStack, copyStack);
-                            copyStack.stackSize = areStackEqual ? Math.min(slotStack.stackSize + copySize, 127)
-                                    : Math.min(copySize, 127);
+                            copyStack.stackSize = areStackEqual ? slotStack.stackSize + copySize : copySize;
                             sendPacket = true;
                         } else if (button == 1) {
                             boolean areStackEqual = slotStack != null && slotStack.isItemEqual(copyStack)
                                     && ItemStack.areItemStackTagsEqual(slotStack, copyStack);
                             if (areStackEqual) {
-                                copyStack.stackSize = Math.min(slotStack.stackSize + 1, 127);
+                                copyStack.stackSize = slotStack.stackSize;
                             } else {
                                 copyStack.stackSize = slotStack == null ? 1 : copySize;
                             }

--- a/src/main/java/com/github/vfyjxf/nee/network/packet/PacketSlotStackChange.java
+++ b/src/main/java/com/github/vfyjxf/nee/network/packet/PacketSlotStackChange.java
@@ -6,6 +6,9 @@ import java.util.List;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+import com.github.vfyjxf.nee.utils.ItemUtils;
 
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
@@ -38,7 +41,7 @@ public class PacketSlotStackChange implements IMessage {
 
     @Override
     public void fromBytes(ByteBuf buf) {
-        this.stack = ByteBufUtils.readItemStack(buf);
+        this.stack = ItemUtils.loadItemStackFromNBT(ByteBufUtils.readTag(buf));
         int craftingSlotsSize = buf.readInt();
         this.craftingSlots = new ArrayList<>(craftingSlotsSize);
         for (int i = 0; i < craftingSlotsSize; i++) {
@@ -49,7 +52,7 @@ public class PacketSlotStackChange implements IMessage {
 
     @Override
     public void toBytes(ByteBuf buf) {
-        ByteBufUtils.writeItemStack(buf, this.stack);
+        ByteBufUtils.writeTag(buf, ItemUtils.writeItemStackToNBT(this.stack, new NBTTagCompound()));
         buf.writeInt(this.craftingSlots.size());
         for (Integer craftingSlot : this.craftingSlots) {
             buf.writeInt(craftingSlot);


### PR DESCRIPTION
Allows stacksizes above 127/byte max to be dragged into pattern terminals. There's no need for this limitation anymore as AE2 can handle much bigger stacksizes without issues.

~~Note that this currently doesn't function in base AE2 terminals in full pack as it's clashing with the AE2 integration from NEIAddons. I will make a separate pr to disable that in config as there's no reason to have two different implementations for this.~~

136k no sweat
![nei-drag](https://github.com/GTNewHorizons/NotEnoughEnergistics/assets/127234178/3a6a66bb-981c-4cd9-8676-45d1f5807ac4)

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16004
