### PR TITLE
The renaming

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:BuildCraftCompat:7.1.17:dev") { transitive = false }
     compileOnly('com.github.GTNewHorizons:EnderIO:2.8.17:dev') { transitive=false }
     compileOnly("com.github.GTNewHorizons:ForestryMC:4.9.7:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.49.22:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.49.55:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:ThaumicEnergistics:1.6.22-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.3.26-gtnh:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Avaritiaddons:1.7.1-GTNH:dev") { transitive = false }

--- a/src/main/java/com/github/vfyjxf/nee/processor/GTPPRecipeProcessor.java
+++ b/src/main/java/com/github/vfyjxf/nee/processor/GTPPRecipeProcessor.java
@@ -32,8 +32,8 @@ public class GTPPRecipeProcessor implements IRecipeProcessor {
         }
 
         try {
-            Class<?> gtRecipeMapClazz = Class.forName("gregtech.api.util.GT_Recipe$GT_Recipe_Map");
-            Class<?> gtppRecipeMapClazz = Class.forName("gregtech.api.util.GTPP_Recipe$GTPP_Recipe_Map_Internal");
+            Class<?> gtRecipeMapClazz = Class.forName("gregtech.api.util.GTRecipe$GT_Recipe_Map");
+            Class<?> gtppRecipeMapClazz = Class.forName("gregtech.api.util.GTPPRecipe$GTPP_Recipe_Map_Internal");
             Collection<?> sMappingsEx = (Collection<?>) gtppRecipeMapClazz.getDeclaredField("sMappingsEx").get(null);
             for (Object gtppMap : sMappingsEx) {
                 boolean mNEIAllowed = gtRecipeMapClazz.getDeclaredField("mNEIAllowed").getBoolean(gtppMap);

--- a/src/main/java/com/github/vfyjxf/nee/processor/GregTech5RecipeProcessor.java
+++ b/src/main/java/com/github/vfyjxf/nee/processor/GregTech5RecipeProcessor.java
@@ -22,7 +22,7 @@ import codechicken.nei.PositionedStack;
 import codechicken.nei.recipe.IRecipeHandler;
 import gregtech.api.enums.ItemList;
 import gregtech.api.recipe.RecipeCategory;
-import gregtech.nei.GT_NEI_DefaultHandler.FixedPositionedStack;
+import gregtech.nei.GTNEIDefaultHandler.FixedPositionedStack;
 
 /**
  * @author vfyjxf
@@ -37,7 +37,7 @@ public class GregTech5RecipeProcessor implements IRecipeProcessor {
         Class<?> gtDH = null;
         Class<?> gtAL = null;
         try {
-            gtDH = Class.forName("gregtech.nei.GT_NEI_DefaultHandler");
+            gtDH = Class.forName("gregtech.nei.GTNEIDefaultHandler");
             gtAL = Class.forName("gregtech.nei.GT_NEI_AssLineHandler");
         } catch (ClassNotFoundException ignored) {}
         gtDefaultClz = gtDH;

--- a/src/main/java/com/github/vfyjxf/nee/utils/ItemUtils.java
+++ b/src/main/java/com/github/vfyjxf/nee/utils/ItemUtils.java
@@ -33,7 +33,7 @@ public final class ItemUtils {
 
     static {
         try {
-            GT_MetaGenerated_ToolClass = Class.forName("gregtech.api.items.GT_MetaGenerated_Tool");
+            GT_MetaGenerated_ToolClass = Class.forName("gregtech.api.items.MetaGeneratedTool");
         } catch (ClassNotFoundException ignored) {}
     }
 


### PR DESCRIPTION
One note on this, some of the reflected classes I could not find at all in the GT5u codebase anymore, so I think they simply don't exist anymore? `GTPP_Recipe_Map_Internal` and `GT_Recipe_Map` don't seem to exist as inner classes of `GTPPRecipe` and `GTRecipe` at all, even after the renaming. Same with `GT_NEI_AssLineHandler`, I could not find this class either as the old or as the new name.