### PR TITLE
do not handle GuiLevelMaintainer dragNdrop

### DIFF
--- a/src/main/java/com/github/vfyjxf/nee/client/GuiEventHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/client/GuiEventHandler.java
@@ -193,7 +193,8 @@ public class GuiEventHandler implements INEIGuiHandler {
         }
 
         if (NEEConfig.enableNEIDragDrop) {
-            if (gui instanceof AEBaseGui && !gui.getClass().getName().contains("com.glodblock.github.client.gui.GuiLevelMaintainer")) {
+            if (gui instanceof AEBaseGui
+                    && !gui.getClass().getName().contains("com.glodblock.github.client.gui.GuiLevelMaintainer")) {
                 if (draggedStack != null) {
                     Slot currentSlot = gui.getSlotAtPosition(mouseX, mouseY);
                     if (currentSlot instanceof SlotFake) {

--- a/src/main/java/com/github/vfyjxf/nee/client/GuiEventHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/client/GuiEventHandler.java
@@ -33,6 +33,7 @@ import com.github.vfyjxf.nee.network.packet.PacketSlotStackChange;
 import com.github.vfyjxf.nee.network.packet.PacketStackCountChange;
 import com.github.vfyjxf.nee.utils.GuiUtils;
 import com.github.vfyjxf.nee.utils.ItemUtils;
+import com.glodblock.github.client.gui.GuiLevelMaintainer;
 
 import appeng.api.events.GuiScrollEvent;
 import appeng.client.gui.AEBaseGui;
@@ -193,8 +194,10 @@ public class GuiEventHandler implements INEIGuiHandler {
         }
 
         if (NEEConfig.enableNEIDragDrop) {
-            if (gui instanceof AEBaseGui
-                    && !gui.getClass().getName().contains("com.glodblock.github.client.gui.GuiLevelMaintainer")) {
+            if (Loader.isModLoaded("ae2fc") && gui instanceof GuiLevelMaintainer) {
+                return false;
+            }
+            if (gui instanceof AEBaseGui) {
                 if (draggedStack != null) {
                     Slot currentSlot = gui.getSlotAtPosition(mouseX, mouseY);
                     if (currentSlot instanceof SlotFake) {

--- a/src/main/java/com/github/vfyjxf/nee/client/GuiEventHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/client/GuiEventHandler.java
@@ -193,7 +193,7 @@ public class GuiEventHandler implements INEIGuiHandler {
         }
 
         if (NEEConfig.enableNEIDragDrop) {
-            if (gui instanceof AEBaseGui) {
+            if (gui instanceof AEBaseGui && !gui.getClass().getName().contains("com.glodblock.github.client.gui.GuiLevelMaintainer")) {
                 if (draggedStack != null) {
                     Slot currentSlot = gui.getSlotAtPosition(mouseX, mouseY);
                     if (currentSlot instanceof SlotFake) {


### PR DESCRIPTION
This PR is a workaround of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18415
When NEE's handler handles GuiLevelMaintainer dragNdrop action before AE2FC's handler , the bug described in that issue happens.
So simply blacklist GuiLevelMaintainer
This is an ugly patch but it works.