### PR TITLE
Update dependencies due to API Change in Forestry and GT5u

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,19 +1,19 @@
 dependencies {
 
-    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-669-GTNH:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.7.69-GTNH:dev")
-    api('com.github.GTNewHorizons:CodeChickenCore:1.4.3:dev')
+    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-673-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.7.72-GTNH:dev")
+    api('com.github.GTNewHorizons:CodeChickenCore:1.4.7:dev')
 
     implementation("com.github.GTNewHorizons:Baubles-Expanded:2.1.9-GTNH:dev")
     implementation("com.github.GTNewHorizons:WirelessCraftingTerminal:1.12.7:dev")
-    implementation("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.106-gtnh:dev")
+    implementation("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.108-gtnh:dev")
 
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.419:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Avaritia:1.70:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Avaritiaddons:1.9.0-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.427:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Avaritia:1.72:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Avaritiaddons:1.9.1-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:BuildCraftCompat:7.1.18:dev") { transitive = false }
     compileOnly('com.github.GTNewHorizons:EnderIO:2.9.22:dev') {transitive=false}
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.10.16:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.10.17:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:GTplusplus:1.12.11:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:ThaumicEnergistics:1.7.11-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Botania:1.12.21-GTNH:dev") { transitive = false }


### PR DESCRIPTION
Forestry API Changed in the never versions so if you require the newest GT5u and depend on NEE then you will run into issues (BlockRenderer requires on both GT5u and NEE)