### PR TITLE
fix: use the player's selected item when transferring

### DIFF
--- a/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
@@ -242,7 +242,9 @@ public class NEEPatternTerminalHandler implements IOverlayHandler {
             int slotIndex = col + row * 3;
 
             if (positionedStack.items != null && positionedStack.items.length > 0) {
+                ItemStack selected = positionedStack.item;
                 positionedStack = positionedStack.copy();
+                positionedStack.setPermutationToRender(selected);
                 ItemStack stack = NEIClientUtils.shiftKey() ? positionedStack.item
                         : positionedStack.getFilteredPermutations().get(0);
 

--- a/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
@@ -122,11 +122,14 @@ public class NEEPatternTerminalHandler implements IOverlayHandler {
                     NEEPatternTerminalHandler.ingredients.clear();
 
                     for (PositionedStack positionedStack : mergedInputs) {
-                        ItemStack currentStack = NEIClientUtils.shiftKey() ? positionedStack.item
-                                : positionedStack.getFilteredPermutations().get(0);
-                        ItemStack preferModItem = ItemUtils.getPreferModItem(positionedStack.items);
+                        ItemStack currentStack =  positionedStack.getFilteredPermutations().get(0);
                         int stackSize = currentStack.stackSize;
-
+                        if (NEIClientUtils.shiftKey())
+                        {
+                            currentStack = positionedStack.item;
+                            currentStack.stackSize = stackSize;
+                        }
+                        ItemStack preferModItem = ItemUtils.getPreferModItem(positionedStack.items);
                         if (preferModItem != null) {
                             currentStack = preferModItem;
                             currentStack.stackSize = stackSize;

--- a/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
@@ -122,10 +122,9 @@ public class NEEPatternTerminalHandler implements IOverlayHandler {
                     NEEPatternTerminalHandler.ingredients.clear();
 
                     for (PositionedStack positionedStack : mergedInputs) {
-                        ItemStack currentStack =  positionedStack.getFilteredPermutations().get(0);
+                        ItemStack currentStack = positionedStack.getFilteredPermutations().get(0);
                         int stackSize = currentStack.stackSize;
-                        if (NEIClientUtils.shiftKey())
-                        {
+                        if (NEIClientUtils.shiftKey()) {
                             currentStack = positionedStack.item;
                             currentStack.stackSize = stackSize;
                         }

--- a/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
@@ -25,6 +25,7 @@ import com.github.vfyjxf.nee.utils.IngredientTracker;
 import com.github.vfyjxf.nee.utils.ItemUtils;
 
 import appeng.util.Platform;
+import codechicken.nei.NEIClientUtils;
 import codechicken.nei.NEIServerUtils;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.api.IOverlayHandler;
@@ -121,7 +122,8 @@ public class NEEPatternTerminalHandler implements IOverlayHandler {
                     NEEPatternTerminalHandler.ingredients.clear();
 
                     for (PositionedStack positionedStack : mergedInputs) {
-                        ItemStack currentStack = positionedStack.getFilteredPermutations().get(0);
+                        ItemStack currentStack = NEIClientUtils.shiftKey() ? positionedStack.item
+                                : positionedStack.getFilteredPermutations().get(0);
                         ItemStack preferModItem = ItemUtils.getPreferModItem(positionedStack.items);
                         int stackSize = currentStack.stackSize;
 
@@ -218,7 +220,9 @@ public class NEEPatternTerminalHandler implements IOverlayHandler {
             }
 
             if (!find) {
-                mergedInputs.add(positionedStack.copy());
+                PositionedStack stack = positionedStack.copy();
+                stack.setPermutationToRender(positionedStack.item);
+                mergedInputs.add(stack);
             }
         }
 
@@ -237,7 +241,8 @@ public class NEEPatternTerminalHandler implements IOverlayHandler {
 
             if (positionedStack.items != null && positionedStack.items.length > 0) {
                 positionedStack = positionedStack.copy();
-                ItemStack stack = positionedStack.getFilteredPermutations().get(0);
+                ItemStack stack = NEIClientUtils.shiftKey() ? positionedStack.item
+                        : positionedStack.getFilteredPermutations().get(0);
 
                 ItemStack preferModItem = ItemUtils.getPreferModItem(positionedStack.items);
                 if (preferModItem != null) {


### PR DESCRIPTION
## Summary
This PR fixes the transferring logic to use the player's selected item instead of the default item.
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25635

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
