### PR TITLE
Fix OreDict Permutations

### DIFF
--- a/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
@@ -126,7 +126,7 @@ public class NEEPatternTerminalHandler implements IOverlayHandler {
                         int stackSize = currentStack.stackSize;
 
                         if (preferModItem != null) {
-                            currentStack = preferModItem.copy();
+                            currentStack = preferModItem;
                             currentStack.stackSize = stackSize;
                         }
 
@@ -210,10 +210,7 @@ public class NEEPatternTerminalHandler implements IOverlayHandler {
 
                         if (areItemStackEqual
                                 && (firstStack.stackSize + currentStack.stackSize) <= firstStack.getMaxStackSize()) {
-                            int mergedSize = firstStack.stackSize + currentStack.stackSize;
-                            for (ItemStack alternate : storedStack.items) {
-                                alternate.stackSize = mergedSize;
-                            }
+                            firstStack.stackSize = firstStack.stackSize + currentStack.stackSize;
                             find = true;
                         }
                     }

--- a/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
@@ -126,7 +126,7 @@ public class NEEPatternTerminalHandler implements IOverlayHandler {
                         int stackSize = currentStack.stackSize;
 
                         if (preferModItem != null) {
-                            currentStack = preferModItem;
+                            currentStack = preferModItem.copy();
                             currentStack.stackSize = stackSize;
                         }
 
@@ -210,7 +210,10 @@ public class NEEPatternTerminalHandler implements IOverlayHandler {
 
                         if (areItemStackEqual
                                 && (firstStack.stackSize + currentStack.stackSize) <= firstStack.getMaxStackSize()) {
-                            storedStack.items[0].stackSize = firstStack.stackSize + currentStack.stackSize;
+                            int mergedSize = firstStack.stackSize + currentStack.stackSize;
+                            for (ItemStack alternate : storedStack.items) {
+                                alternate.stackSize = mergedSize;
+                            }
                             find = true;
                         }
                     }


### PR DESCRIPTION
## Summary
When merging identical ingredients with several ore-dict alternatives (e.g. Obsidian Plate). the counter could get stuck instead of summing up to the required amount.

Error:
<img width="384" height="510" alt="image" src="https://github.com/user-attachments/assets/ac17b9ba-2323-4af6-8a27-456e2d32b05c" />
<img width="396" height="176" alt="image" src="https://github.com/user-attachments/assets/81e3d6f7-dd9f-4e9d-9024-74f78cdfdf3b" />
issue: https://discord.com/channels/181078474394566657/522098956491030558/1527019090319769741


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
