### PR TITLE
Ensure dire crafter stack size

### DIFF
--- a/src/main/java/com/github/vfyjxf/nee/network/packet/PacketExtremeRecipe.java
+++ b/src/main/java/com/github/vfyjxf/nee/network/packet/PacketExtremeRecipe.java
@@ -61,6 +61,7 @@ public class PacketExtremeRecipe implements IMessage {
                 for (int i = 0; i < recipeInputs.length; i++) {
                     currentStack = (NBTTagCompound) message.input.getTag("#" + i);
                     recipeInputs[i] = currentStack == null ? null : ItemUtils.loadItemStackFromNBT(currentStack);
+                    if (recipeInputs[i] != null) recipeInputs[i].stackSize = 0;
                 }
                 int inputIndex = 0;
                 for (int i = 81; i < 162; i++) {


### PR DESCRIPTION
## Summary
Ensure dire crafter fake slot stack size is set to 0
[mirroring](https://github.com/GTNewHorizons/Avaritiaddons/blob/f614ee8ce45715c58de49069a693c84a825d3b4b/src/main/java/wanion/avaritiaddons/block/extremeautocrafter/ContainerExtremeAutoCrafter.java#L73) the default behavior when setting the crafter manually

Closes GTNewHorizons/Dupes-Exploits-GTNH#343

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
