### PR TITLE
add bq ae2 nei overlay support

### DIFF
--- a/src/main/java/com/github/vfyjxf/nee/processor/BetterQuestingRecipeProcessor.java
+++ b/src/main/java/com/github/vfyjxf/nee/processor/BetterQuestingRecipeProcessor.java
@@ -40,7 +40,10 @@ public class BetterQuestingRecipeProcessor implements IRecipeProcessor {
     @Override
     public List<PositionedStack> getRecipeOutput(IRecipeHandler recipe, int recipeIndex, String identifier) {
         List<PositionedStack> recipeOutput = new ArrayList<>();
-        recipeOutput.add(recipe.getOtherStacks(recipeIndex).get(0));
+        if (this.getAllOverlayIdentifier().contains(identifier)) {
+            recipeOutput.add(recipe.getOtherStacks(recipeIndex).get(0));
+            return recipeOutput;
+        }
         return recipeOutput;
     }
 }

--- a/src/main/java/com/github/vfyjxf/nee/processor/BetterQuestingRecipeProcessor.java
+++ b/src/main/java/com/github/vfyjxf/nee/processor/BetterQuestingRecipeProcessor.java
@@ -40,10 +40,7 @@ public class BetterQuestingRecipeProcessor implements IRecipeProcessor {
     @Override
     public List<PositionedStack> getRecipeOutput(IRecipeHandler recipe, int recipeIndex, String identifier) {
         List<PositionedStack> recipeOutput = new ArrayList<>();
-        if (this.getAllOverlayIdentifier().contains(identifier)) {
-            recipeOutput.addAll(recipe.getOtherStacks(recipeIndex));
-            return recipeOutput;
-        }
+        recipeOutput.add(recipe.getOtherStacks(recipeIndex).get(0));
         return recipeOutput;
     }
 }

--- a/src/main/java/com/github/vfyjxf/nee/processor/BetterQuestingRecipeProcessor.java
+++ b/src/main/java/com/github/vfyjxf/nee/processor/BetterQuestingRecipeProcessor.java
@@ -1,0 +1,49 @@
+package com.github.vfyjxf.nee.processor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+
+import codechicken.nei.PositionedStack;
+import codechicken.nei.recipe.IRecipeHandler;
+
+public class BetterQuestingRecipeProcessor implements IRecipeProcessor {
+
+    @Nonnull
+    @Override
+    public Set<String> getAllOverlayIdentifier() {
+        return new HashSet<>(Arrays.asList("bq_quest"));
+    }
+
+    @Nonnull
+    @Override
+    public String getRecipeProcessorId() {
+        return "betterquesting";
+    }
+
+    @Nonnull
+    @Override
+    public List<PositionedStack> getRecipeInput(IRecipeHandler recipe, int recipeIndex, String identifier) {
+        List<PositionedStack> recipeInputs = new ArrayList<>();
+        if (this.getAllOverlayIdentifier().contains(identifier)) {
+            recipeInputs.addAll(recipe.getIngredientStacks(recipeIndex));
+            return recipeInputs;
+        }
+        return recipeInputs;
+    }
+
+    @Nonnull
+    @Override
+    public List<PositionedStack> getRecipeOutput(IRecipeHandler recipe, int recipeIndex, String identifier) {
+        List<PositionedStack> recipeOutput = new ArrayList<>();
+        if (this.getAllOverlayIdentifier().contains(identifier)) {
+            recipeOutput.addAll(recipe.getOtherStacks(recipeIndex));
+            return recipeOutput;
+        }
+        return recipeOutput;
+    }
+}

--- a/src/main/java/com/github/vfyjxf/nee/processor/BetterQuestingRecipeProcessor.java
+++ b/src/main/java/com/github/vfyjxf/nee/processor/BetterQuestingRecipeProcessor.java
@@ -42,7 +42,6 @@ public class BetterQuestingRecipeProcessor implements IRecipeProcessor {
         List<PositionedStack> recipeOutput = new ArrayList<>();
         if (this.getAllOverlayIdentifier().contains(identifier)) {
             recipeOutput.add(recipe.getOtherStacks(recipeIndex).get(0));
-            return recipeOutput;
         }
         return recipeOutput;
     }

--- a/src/main/java/com/github/vfyjxf/nee/processor/RecipeProcessor.java
+++ b/src/main/java/com/github/vfyjxf/nee/processor/RecipeProcessor.java
@@ -98,6 +98,11 @@ public class RecipeProcessor {
             recipeProcessors.add(new GoodGeneratorRecipeProcessor());
         }
 
+        if (Loader.isModLoaded("betterquesting") && Loader.isModLoaded("bq_standard")) {
+            NotEnoughEnergistics.logger.info("Found BetterQuesting, install BetterQuesting support");
+            recipeProcessors.add(new BetterQuestingRecipeProcessor());
+        }
+
         NotEnoughEnergistics.logger.info("-----Not Enough Energistics Init  Finished-----");
     }
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
well we should not just support the NEI bookmark, just make the fake pattern easier to make!
effect:
NEI:
<img width="349" height="270" alt="Screenshot 2026-08-15 at 13 59 30" src="https://github.com/user-attachments/assets/8154b806-0246-409a-933b-e4d7157a8cd6" />
Pattern:
<img width="344" height="190" alt="Screenshot 2026-08-15 at 14 00 05" src="https://github.com/user-attachments/assets/c0a84ba5-c00b-4318-95ca-ee01d1e54c10" />

NEI: 
<img width="348" height="284" alt="Screenshot 2026-08-15 at 13 59 43" src="https://github.com/user-attachments/assets/fdced091-e360-495b-a231-d240b7aaa3c6" />
Pattern:
<img width="345" height="192" alt="Screenshot 2026-08-15 at 14 00 15" src="https://github.com/user-attachments/assets/b6e40d9c-136b-4140-9498-51dab80a1df5" />

needs: https://github.com/GTNewHorizons/BetterQuesting/pull/248 to merge

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
