### PR TITLE
Stop transferring furnace fuel into ME patterns

### DIFF
--- a/src/main/java/com/github/vfyjxf/nee/processor/VanillaRecipeProcessor.java
+++ b/src/main/java/com/github/vfyjxf/nee/processor/VanillaRecipeProcessor.java
@@ -34,7 +34,10 @@ public class VanillaRecipeProcessor implements IRecipeProcessor {
         List<PositionedStack> recipeInputs = new ArrayList<>();
         if (this.getAllOverlayIdentifier().contains(identifier)) {
             recipeInputs.addAll(recipe.getIngredientStacks(recipeIndex));
-            recipeInputs.addAll(recipe.getOtherStacks(recipeIndex));
+            // for furnace recipes the other stack is the cycling fuel, which is not part of the pattern
+            if (!"smelting".equals(identifier)) {
+                recipeInputs.addAll(recipe.getOtherStacks(recipeIndex));
+            }
         }
         return recipeInputs;
     }


### PR DESCRIPTION
## Summary
For smelting recipes NEI exposes the cycling fuel slot as an "other stack", so it ended up in the pattern as a second input, picking whatever fuel happened to be rendered at that moment.

Fuel is now skipped for the smelting identifier. Brewing and fuel recipes are unchanged.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
