### PR TITLE
Fix processing pattern output transfer limit

### DIFF
--- a/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
+++ b/src/main/java/com/github/vfyjxf/nee/nei/NEEPatternTerminalHandler.java
@@ -164,7 +164,7 @@ public class NEEPatternTerminalHandler implements IOverlayHandler {
                     }
 
                     for (PositionedStack positionedStack : outputs) {
-                        if (outputIndex >= 4 || positionedStack == null || positionedStack.item == null) {
+                        if (positionedStack == null || positionedStack.item == null) {
                             continue;
                         }
 


### PR DESCRIPTION
## Summary
Remove limit preventing recipe overlay into Processing Pattern Terminals when they are in 4 inputs -> 16 ouputs configuration.


## Testing

Daily 707

With this recipe:
<img width="338" height="284" alt="image" src="https://github.com/user-attachments/assets/63e3acdb-277b-40ff-bd45-ae0023c73c3f" />


### Before
<img width="343" height="191" alt="image" src="https://github.com/user-attachments/assets/382fac9a-fee1-4d34-9a1a-f2ff9b022c0d" />

### After
<img width="347" height="184" alt="image" src="https://github.com/user-attachments/assets/54ef7dbd-0427-40ed-9653-40126bbef8e7" />


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
